### PR TITLE
fix(requirements): lock onnx version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ tensorflow
 numpy 
 torch
 torchvision
-onnx
+onnx==1.8.1
 onnx2keras


### PR DESCRIPTION
Another fix for the same issue was already merged:
https://github.com/gmalivenko/pytorch2keras/pull/133

----


See: https://github.com/onnx/onnx/issues/582#issuecomment-824263936


> As of 2021 March 15th, the optimizer is no longer part of the `onnx` repo ([source](https://github.com/onnx/onnx/pull/3288)).
> 
> If you're installing code that depends on it and get errors, an easy workaround is to install a slightly older version of onnx:
> 
> ```
> pip install onnx==1.8.1
> ```


> Please note that the onnxoptimizer is still available and ongoing from another repo: https://github.com/onnx/optimizer. As mentioned above, it was moved out from ONNX package since ONNX 1.9.0. Thanks

